### PR TITLE
fix: window can not get focus at mapped

### DIFF
--- a/platformplugin/dplatformwindowhelper.cpp
+++ b/platformplugin/dplatformwindowhelper.cpp
@@ -488,6 +488,12 @@ void DPlatformWindowHelper::requestActivateWindow()
 #endif
 
     helper->m_frameWindow->handle()->requestActivateWindow();
+#ifdef Q_OS_LINUX
+    // 对于有parent的窗口，需要调用此接口让其获得输入焦点
+    xcb_set_input_focus(DPlatformIntegration::xcbConnection()->xcb_connection(),
+                        XCB_INPUT_FOCUS_PARENT, helper->m_nativeWindow->QNativeWindow::winId(),
+                        DPlatformIntegration::xcbConnection()->time());
+#endif
 }
 
 bool DPlatformWindowHelper::setKeyboardGrabEnabled(bool grab)


### PR DESCRIPTION
On KWin

https://github.com/linuxdeepin/internal-discussion/issues/1430
https://github.com/linuxdeepin/internal-discussion/issues/1346

修复在kwin中，窗口第一次启动后输入框无法获取焦点（qcef应用稳定出现）