### PR TITLE
fix: delete platform backing store object

### DIFF
--- a/platformplugin/dframewindow.cpp
+++ b/platformplugin/dframewindow.cpp
@@ -161,6 +161,8 @@ DFrameWindow::~DFrameWindow()
     if (nativeWindowXPixmap != XCB_PIXMAP_NONE)
         xcb_free_pixmap(DPlatformIntegration::xcbConnection()->xcb_connection(), nativeWindowXPixmap);
 #endif
+
+    delete platformBackingStore;
 }
 
 QWindow *DFrameWindow::contentWindow() const


### PR DESCRIPTION
在DFrameWindow窗口销毁时销毁QPlatformBackingStore对象