### PR TITLE
fix: build failure under Qt 5.13

### DIFF
--- a/platformplugin/dxcbxsettings.cpp
+++ b/platformplugin/dxcbxsettings.cpp
@@ -48,17 +48,17 @@
 
 #define Q_XCB_REPLY_CONNECTION_ARG(connection, ...) connection
 
-struct QStdFreeDeleter {
+struct DStdFreeDeleter {
     void operator()(void *p) const noexcept { return std::free(p); }
 };
 
 #define Q_XCB_REPLY(call, ...) \
-    std::unique_ptr<call##_reply_t, QStdFreeDeleter>( \
+    std::unique_ptr<call##_reply_t, DStdFreeDeleter>( \
         call##_reply(Q_XCB_REPLY_CONNECTION_ARG(__VA_ARGS__), call(__VA_ARGS__), nullptr) \
     )
 
 #define Q_XCB_REPLY_UNCHECKED(call, ...) \
-    std::unique_ptr<call##_reply_t, QStdFreeDeleter>( \
+    std::unique_ptr<call##_reply_t, DStdFreeDeleter>( \
         call##_reply(Q_XCB_REPLY_CONNECTION_ARG(__VA_ARGS__), call##_unchecked(__VA_ARGS__), nullptr) \
     )
 


### PR DESCRIPTION
```
dxcbxsettings.cpp:51:8: error: redefinition of ‘struct QStdFreeDeleter’
   51 | struct QStdFreeDeleter {
      |        ^~~~~~~~~~~~~~~
In file included from /usr/include/qtxcb-private/qxcbconnection.h:56,
                 from /usr/include/qtxcb-private/qxcbobject.h:43,
                 from /usr/include/qtxcb-private/qxcbscreen.h:51,
                 from dxcbxsettings.h:43,
                 from dxcbxsettings.cpp:40:
/usr/include/qtxcb-private/qxcbconnection_basic.h:160:8: note: previous definition of ‘struct QStdFreeDeleter’
  160 | struct QStdFreeDeleter {
      |        ^~~~~~~~~~~~~~~
make[1]: *** [Makefile.qt5platform-plugin:550: dxcbxsettings.o] Error 1
```