### PR TITLE
fix: use client message notify window xsettings changed

### DIFF
--- a/platformplugin/dplatformintegration.h
+++ b/platformplugin/dplatformintegration.h
@@ -52,6 +52,8 @@ public:
     static bool setEnableNoTitlebar(QWindow *window, bool enable);
     static bool isEnableNoTitlebar(const QWindow *window);
 
+    // Warning: 调用 buildNativeSettings，会导致object的QMetaObject对象被更改
+    // 无法使用QMetaObject::cast，不能使用QObject::findChild等接口查找子类，也不能使用qobject_cast转换对象指针类型
     static bool buildNativeSettings(QObject *object, quint32 settingWindow);
     static void clearNativeSettings(quint32 settingWindow);
 

--- a/platformplugin/dxcbxsettings.h
+++ b/platformplugin/dxcbxsettings.h
@@ -69,6 +69,7 @@ public:
     void removeCallbackForHandle(void *handle);
 
     static bool handlePropertyNotifyEvent(const xcb_property_notify_event_t *event);
+    static bool handleClientMessageEvent(const xcb_client_message_event_t *event);
 
     static void clearSettings(xcb_window_t setting_window);
 private:

--- a/platformplugin/xcbnativeeventfilter.cpp
+++ b/platformplugin/xcbnativeeventfilter.cpp
@@ -230,6 +230,14 @@ bool XcbNativeEventFilter::nativeEventFilter(const QByteArray &eventType, void *
             break;
         }
 #endif
+        case XCB_CLIENT_MESSAGE: {
+            xcb_client_message_event_t *ev = reinterpret_cast<xcb_client_message_event_t*>(event);
+
+            if (DXcbXSettings::handleClientMessageEvent(ev)) {
+                return true;
+            }
+            break;
+        }
         default:
             static auto updateScaleLogcailDpi = qApp->property("_d_updateScaleLogcailDpi").toULongLong();
 #if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)


### PR DESCRIPTION
窗口的属性改变事件可能会被其它事件过滤器接收并处理
因此改用client message通知窗口级别的xsettings属性变化
此client message事件发送给xsettings owner，且在事件数据
中携带属性变化窗口的window id。