### PR TITLE
fix: clear window blur property if the blur areas/paths is empty

### DIFF
--- a/platformplugin/dplatformintegration.cpp
+++ b/platformplugin/dplatformintegration.cpp
@@ -213,10 +213,9 @@ bool DPlatformIntegration::setEnableNoTitlebar(QWindow *window, bool enable)
             return false;
 
         QNativeWindow *xw = static_cast<QNativeWindow*>(window->handle());
+        window->setProperty(noTitlebar, true);
 
         if (!xw) {
-            window->setProperty(noTitlebar, true);
-
             return true;
         }
 

--- a/platformplugin/utility_x11.cpp
+++ b/platformplugin/utility_x11.cpp
@@ -532,7 +532,9 @@ bool Utility::blurWindowBackground(const quint32 WId, const QVector<BlurArea> &a
         }
 
         clearWindowProperty(WId, DXcbWMSupport::instance()->_net_wm_deepin_blur_region_mask);
-        setWindowProperty(WId, atom, XCB_ATOM_CARDINAL, rects.constData(), rects.size(), sizeof(quint32) * 8);
+
+        if (!areas.isEmpty())
+            setWindowProperty(WId, atom, XCB_ATOM_CARDINAL, rects.constData(), rects.size(), sizeof(quint32) * 8);
     }
 
     return true;
@@ -566,6 +568,11 @@ bool Utility::blurWindowBackgroundByPaths(const quint32 WId, const QList<QPainte
 
         if (atom == XCB_NONE)
             return false;
+
+        if (paths.isEmpty()) {
+            clearWindowProperty(WId, DXcbWMSupport::instance()->_net_wm_deepin_blur_region_mask);
+            return true;
+        }
 
         QVector<quint32> rects;
 


### PR DESCRIPTION
fix isEnableNoTitlebar return false of a no titlebar enabled window

修复设置空的模糊区域时无法清理窗口的模糊背景
修复窗口开启无标题栏模式后isEnableNoTitlebar返回的值错误