### PR TITLE
feat: support dynamic create properties for DNativeSettings

### DIFF
--- a/platformplugin/dnativesettings.h
+++ b/platformplugin/dnativesettings.h
@@ -25,6 +25,8 @@
 
 #include <QObject>
 #include <QSet>
+#include <private/qobject_p.h>
+#include <private/qmetaobjectbuilder_p.h>
 
 DPP_BEGIN_NAMESPACE
 
@@ -33,24 +35,25 @@ class DXcbXSettings;
 typedef DXcbXSettings NativeSettings;
 #endif
 
-class DNativeSettings
+class DNativeSettings : public QAbstractDynamicMetaObject
 {
 public:
     explicit DNativeSettings(QObject *base, quint32 settingsWindow);
     ~DNativeSettings();
 
-    bool isEmpty() const;
-
 private:
     void init();
+
+    int createProperty(const char *, const char *) override;
+    int metaCall(QMetaObject::Call, int _id, void **) override;
+
     static void onPropertyChanged(void *screen, const QByteArray &name, const QVariant &property, DNativeSettings *handle);
 
-    static const QMetaObject *metaObject(QObject *object);
-    static int qt_metacall(QObject *object, QMetaObject::Call _c, int _id, void **_a);
-
     QObject *m_base;
-    QMetaObject *m_metaObject = nullptr;
-    QSet<QByteArray> m_registerProperties;
+    QMetaObject *m_metaObject;
+    QMetaObjectBuilder m_objectBuilder;
+    int m_firstProperty;
+    int m_propertyCount;
     int m_propertySignalIndex;
     int m_flagPropertyIndex;
     NativeSettings *m_settings = nullptr;

--- a/platformplugin/dplatformintegration.cpp
+++ b/platformplugin/dplatformintegration.cpp
@@ -242,14 +242,7 @@ bool DPlatformIntegration::isEnableNoTitlebar(const QWindow *window)
 bool DPlatformIntegration::buildNativeSettings(QObject *object, quint32 settingWindow)
 {
     // 跟随object销毁
-    DNativeSettings *settings = new DNativeSettings(object, settingWindow);
-
-    if (settings->isEmpty()) {
-        delete settings;
-        return false;
-    }
-
-    return true;
+    return new DNativeSettings(object, settingWindow);
 }
 
 void DPlatformIntegration::clearNativeSettings(quint32 settingWindow)

--- a/platformplugin/dxcbxsettings.cpp
+++ b/platformplugin/dxcbxsettings.cpp
@@ -353,10 +353,16 @@ public:
             const QByteArray &key = i.key();
             quint16 key_size = key.size();
 
-            if (value.value.type() == QVariant::Color) {
+            switch (value.value.type()) {
+            case QMetaType::QColor:
                 type = XSettingsTypeColor;
-            } else if (value.value.type() == QVariant::Int) {
+                break;
+            case QMetaType::Int:
+            case QMetaType::Bool:
                 type = XSettingsTypeInteger;
+                break;
+            default:
+                break;
             }
 
             xSettings.append(type); //type


### PR DESCRIPTION
Use QAbstractDynamicMetaObject

支持通过QObject::property/setProperty读写未在QObject中定义对应属性的native设置项